### PR TITLE
Add edit resolution support to stored messages

### DIFF
--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,5 +1,7 @@
 export type ThreadSummaryPayload = {
     key: string;
+    resolvedKey?: string;
+    editOf?: string;
     preview: string;
     title?: string;
     mimeType: string;
@@ -11,6 +13,8 @@ export type ThreadSummaryPayload = {
 
 export type ThreadNodePayload = {
     key: string;
+    resolvedKey?: string;
+    editOf?: string;
     parent?: string;
     title?: string;
     mimeType: string;
@@ -23,6 +27,8 @@ export type ThreadNodePayload = {
 
 export type BulkDataRecord = {
     key: string;
+    resolvedKey?: string;
+    editOf?: string;
     found: boolean;
     mimeType?: string;
     isText?: boolean;

--- a/pkg/apiServer/apiServer.go
+++ b/pkg/apiServer/apiServer.go
@@ -88,7 +88,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) { // AC
 	// w.Header().Set("Access-Control-Allow-Credentials", "true")
 	w.Header().Set(
 		"Access-Control-Expose-Headers",
-		"Content-Type, Content-Length, X-Ouroboros-Key, X-Ouroboros-Mime, X-Ouroboros-Is-Text, X-Ouroboros-Parent, X-Ouroboros-Children, X-Ouroboros-Created-At, X-Ouroboros-Title",
+		"Content-Type, Content-Length, X-Ouroboros-Key, X-Ouroboros-Requested-Key, X-Ouroboros-Resolved-Key, X-Ouroboros-Edit-Of, X-Ouroboros-Mime, X-Ouroboros-Is-Text, X-Ouroboros-Parent, X-Ouroboros-Children, X-Ouroboros-Created-At, X-Ouroboros-Title",
 	)
 
 	if r.Method == http.MethodOptions {

--- a/pkg/apiServer/bulk.go
+++ b/pkg/apiServer/bulk.go
@@ -24,6 +24,8 @@ type bulkDataRequest struct {
 
 type bulkDataRecord struct {
 	Key            string `json:"key"`
+	ResolvedKey    string `json:"resolvedKey,omitempty"`
+	EditOf         string `json:"editOf,omitempty"`
 	Found          bool   `json:"found"`
 	MimeType       string `json:"mimeType,omitempty"`
 	IsText         bool   `json:"isText,omitempty"`
@@ -124,6 +126,16 @@ func (s *Server) fetchBulkRecord(r *http.Request, keyHex string, includeBinary b
 		IsText:    data.IsText,
 		SizeBytes: len(data.Content),
 		Title:     data.Title,
+	}
+	resolvedKey := data.ResolvedKey
+	if resolvedKey.IsZero() {
+		resolvedKey = data.Key
+	}
+	if resolvedKey != data.Key {
+		record.ResolvedKey = resolvedKey.String()
+	}
+	if !data.EditOf.IsZero() {
+		record.EditOf = data.EditOf.String()
 	}
 	if !data.CreatedAt.IsZero() {
 		record.CreatedAt = data.CreatedAt.UTC().Format(time.RFC3339Nano)

--- a/pkg/apiServer/meta.go
+++ b/pkg/apiServer/meta.go
@@ -20,26 +20,30 @@ const (
 )
 
 type threadSummary struct {
-	Key        string `json:"key"`
-	Preview    string `json:"preview"`
-	Title      string `json:"title,omitempty"`
-	MimeType   string `json:"mimeType"`
-	IsText     bool   `json:"isText"`
-	SizeBytes  int    `json:"sizeBytes"`
-	ChildCount int    `json:"childCount"`
-	CreatedAt  string `json:"createdAt,omitempty"`
+	Key         string `json:"key"`
+	ResolvedKey string `json:"resolvedKey,omitempty"`
+	EditOf      string `json:"editOf,omitempty"`
+	Preview     string `json:"preview"`
+	Title       string `json:"title,omitempty"`
+	MimeType    string `json:"mimeType"`
+	IsText      bool   `json:"isText"`
+	SizeBytes   int    `json:"sizeBytes"`
+	ChildCount  int    `json:"childCount"`
+	CreatedAt   string `json:"createdAt,omitempty"`
 }
 
 type threadNode struct {
-	Key       string   `json:"key"`
-	Parent    string   `json:"parent,omitempty"`
-	Title     string   `json:"title,omitempty"`
-	MimeType  string   `json:"mimeType"`
-	IsText    bool     `json:"isText"`
-	SizeBytes int      `json:"sizeBytes"`
-	CreatedAt string   `json:"createdAt,omitempty"`
-	Depth     int      `json:"depth"`
-	Children  []string `json:"children"`
+	Key         string   `json:"key"`
+	ResolvedKey string   `json:"resolvedKey,omitempty"`
+	EditOf      string   `json:"editOf,omitempty"`
+	Parent      string   `json:"parent,omitempty"`
+	Title       string   `json:"title,omitempty"`
+	MimeType    string   `json:"mimeType"`
+	IsText      bool     `json:"isText"`
+	SizeBytes   int      `json:"sizeBytes"`
+	CreatedAt   string   `json:"createdAt,omitempty"`
+	Depth       int      `json:"depth"`
+	Children    []string `json:"children"`
 }
 
 func (s *Server) handleThreadSummaries(w http.ResponseWriter, r *http.Request) {
@@ -111,6 +115,12 @@ func (s *Server) handleThreadSummaries(w http.ResponseWriter, r *http.Request) {
 			IsText:     data.IsText,
 			SizeBytes:  len(data.Content),
 			ChildCount: len(data.Children),
+		}
+		if data.ResolvedKey != data.Key {
+			summary.ResolvedKey = data.ResolvedKey.String()
+		}
+		if !data.EditOf.IsZero() {
+			summary.EditOf = data.EditOf.String()
 		}
 		if !data.CreatedAt.IsZero() {
 			summary.CreatedAt = data.CreatedAt.UTC().Format(time.RFC3339Nano)
@@ -203,6 +213,12 @@ func (s *Server) handleThreadNodeStream(w http.ResponseWriter, r *http.Request) 
 			IsText:    data.IsText,
 			SizeBytes: len(data.Content),
 			Depth:     item.depth,
+		}
+		if data.ResolvedKey != data.Key {
+			node.ResolvedKey = data.ResolvedKey.String()
+		}
+		if !data.EditOf.IsZero() {
+			node.EditOf = data.EditOf.String()
 		}
 		if !data.CreatedAt.IsZero() {
 			node.CreatedAt = data.CreatedAt.UTC().Format(time.RFC3339Nano)

--- a/pkg/apiServer/types.go
+++ b/pkg/apiServer/types.go
@@ -32,6 +32,7 @@ type createMetadata struct {
 	IsText                  *bool    `json:"is_text"`
 	Filename                string   `json:"filename"`
 	Title                   string   `json:"title,omitempty"`
+	EditOf                  string   `json:"edit_of,omitempty"`
 }
 
 type AuthFunc func(req *http.Request, db *ouroboros.OuroborosDB) error

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -9,4 +9,5 @@ type Metadata struct {
 	CreatedAt time.Time `json:"created_at"`
 	Title     string    `json:"title,omitempty"`
 	MimeType  string    `json:"mime_type,omitempty"`
+	EditOf    string    `json:"edit_of,omitempty"`
 }


### PR DESCRIPTION
## Summary
- add edit metadata to stored records and resolve the newest edit when fetching data
- expose resolved edit information through API headers, thread streams, and bulk fetch responses
- update frontend API types and tests to cover edit resolution and merged children

## Testing
- go test ./... *(fails: missing local replacement for github.com/i5heu/ouroboros-kv)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dd27c13588330b2d315c4252680cb)